### PR TITLE
Test/12/welding-machine-data-simulator-service: 도커파일 포트 번호 수정   

### DIFF
--- a/services/welding-machine-data-simulator-service/Dockerfile
+++ b/services/welding-machine-data-simulator-service/Dockerfile
@@ -19,10 +19,10 @@ COPY app/ ./app/
 RUN mkdir -p logs
 
 # 포트 노출
-EXPOSE 8008
+EXPOSE 8016
 
 # 환경 변수 설정
 ENV PYTHONPATH=/app
 
 # 애플리케이션 실행
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8008"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8016"]


### PR DESCRIPTION
## ✨ Description 
- 도커파일 포트 번호 8008 -> 8016 으로 수정 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - 시뮬레이터 서비스의 기본 포트를 8008에서 8016으로 변경했습니다.
  - 영향: 서비스 접속 시 새 포트(8016)를 사용해야 합니다. 북마크, 프록시/게이트웨이 설정, 방화벽 규칙, 모니터링 및 헬스체크 엔드포인트를 업데이트하세요.
  - 배포 환경에서 기존 포트(8008)는 더 이상 사용되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->