### PR TITLE
feat/24/welding-machine-data-simulator-service , welding-machine-data-simulator-service: 스프링 부트 게이트웨이 연동 & 시뮬레이터 업데이트 

### DIFF
--- a/services/welding-machine-data-simulator-service/app/config/settings.py
+++ b/services/welding-machine-data-simulator-service/app/config/settings.py
@@ -4,6 +4,9 @@ from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
+    # ✅ 환경 구분 (기본값을 local로 변경)
+    environment: str = "production"  # 기본값을 다시 local로 변경
+
     # Azure Storage 설정
     azure_connection_string: str
     azure_container_name: str = "simulator-data"
@@ -15,24 +18,108 @@ class Settings(BaseSettings):
     scheduler_interval_minutes: int = 1
     batch_size: int = 10
 
-    # Welding Machine 모델 서비스 설정
+    # ✅ 기존 호환성을 위한 필드 (deprecated but needed)
     welding_machine_url: str = "http://localhost:8006"
+
+    # ✅ 환경별 서비스 URL 설정
+    # 로컬 개발
+    local_gateway_url: str = "http://localhost:8088"
+    local_model_service_url: str = "http://localhost:8006"
+
+    # Docker Compose
+    docker_gateway_url: str = "http://gateway:8088"
+    docker_model_service_url: str = "http://welding-model-service:8006"
+
+    # AKS Kubernetes (내부 서비스 통신)
+    kubernetes_gateway_url: str = "http://gateway.smart-be.svc.cluster.local:8088"
+    kubernetes_model_service_url: str = "http://sf-welding-machine-defect-detection-model-service.sf-welding-machine-defect-detection-model-service.svc.cluster.local:80"
+
+    # ✅ Production (현재 실제 배포된 URL) - 기본값으로 설정
+    production_gateway_url: str = "http://20.249.138.42:8088"  # 배포시 기본값
+    production_model_service_url: str = "http://20.249.138.42:8088/api/v1/welding/defect"
+
+    # HTTP 설정
+    spring_boot_timeout: int = 30
+    spring_boot_max_retries: int = 3
+    http_timeout: int = 30
+    max_retries: int = 3
 
     # 로그 설정
     log_directory: str = "logs"
     log_filename: str = "welding_anomaly_detections.json"
     error_log_filename: str = "welding_errors.json"
 
-    # HTTP 클라이언트 설정
-    http_timeout: int = 30
-    max_retries: int = 3
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        # ✅ 명시적으로 environment가 설정되지 않은 경우에만 자동 감지
+        if not kwargs.get('environment') and not os.getenv('ENVIRONMENT'):
+            # 특정 조건에서만 production으로 감지 (더 엄격한 조건)
+            if (hasattr(self, 'azure_connection_string') and
+                self.azure_connection_string and
+                self.azure_connection_string != "your_azure_connection_string" and
+                "localhost" not in self.azure_connection_string and
+                # 추가 조건: Kubernetes 환경 변수 존재 여부
+                    (os.getenv('KUBERNETES_SERVICE_HOST') or os.getenv('WEBSITE_HOSTNAME'))):
+                self.environment = "production"
+            else:
+                self.environment = "local"
+
+    @property
+    def gateway_service_url(self) -> str:
+        """환경에 따른 게이트웨이 서비스 URL"""
+        url_map = {
+            "local": self.local_gateway_url,
+            "development": self.local_gateway_url,
+            "docker": self.docker_gateway_url,
+            "kubernetes": self.kubernetes_gateway_url,
+            "production": self.production_gateway_url,
+        }
+        return url_map.get(self.environment, self.local_gateway_url)
+
+    @property
+    def model_service_url(self) -> str:
+        """환경에 따른 모델 서빙 서비스 URL"""
+        url_map = {
+            "local": self.local_model_service_url,
+            "development": self.local_model_service_url,
+            "docker": self.docker_model_service_url,
+            "kubernetes": self.kubernetes_model_service_url,
+            "production": self.production_model_service_url,
+        }
+        return url_map.get(self.environment, self.local_model_service_url)
 
     @property
     def model_services(self) -> Dict[str, str]:
-        """Welding Machine 모델 서비스 URL"""
+        """Welding Machine 모델 서비스 URL (기존 호환성 유지)"""
         return {
-            "welding-machine": self.welding_machine_url
+            "welding-machine": self.welding_machine_url  # 기존 필드 사용
         }
+
+    @property
+    def spring_boot_service_url(self) -> str:
+        """기존 호환성을 위한 별칭"""
+        return self.gateway_service_url
+
+    @property
+    def spring_boot_endpoints(self) -> Dict[str, str]:
+        """스프링부트 서비스 엔드포인트 (게이트웨이 경유)"""
+        base_url = self.gateway_service_url
+
+        return {
+            "welding_data": f"{base_url}/weldingMachineDefectDetectionLogs",
+            "health": f"{base_url}/actuator/health",
+            "status": f"{base_url}/weldingMachineDefectDetectionLogs"
+        }
+
+    @property
+    def is_local_environment(self) -> bool:
+        """로컬 환경 여부 확인"""
+        return self.environment in ["local", "development"]
+
+    @property
+    def is_production_environment(self) -> bool:
+        """프로덕션 환경 여부 확인"""
+        return self.environment in ["production", "kubernetes"]
 
     model_config = {
         "env_file": ".env",

--- a/services/welding-machine-data-simulator-service/app/services/spring_client.py
+++ b/services/welding-machine-data-simulator-service/app/services/spring_client.py
@@ -1,0 +1,202 @@
+import asyncio
+import httpx
+import logging
+from typing import Dict, Any, Optional
+from datetime import datetime
+from app.config.settings import settings
+
+logger = logging.getLogger(__name__)
+
+
+class SpringBootClient:
+    """스프링부트 서비스와 통신하는 HTTP 클라이언트 (게이트웨이 경유)"""
+
+    def __init__(self):
+        # spring_boot_service_url → gateway_service_url 변경
+        self.base_url = settings.gateway_service_url
+        self.timeout = settings.spring_boot_timeout
+        self.max_retries = settings.spring_boot_max_retries
+
+    async def send_sensor_data(self, sensor_data: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        센서 데이터를 스프링부트 서비스로 전송 (게이트웨이 경유, MSAez 스타일)
+
+        Args:
+            sensor_data: 센서 데이터 (signal_type, values, machine_id, timestamp 포함)
+
+        Returns:
+            스프링부트 서비스 응답
+
+        Raises:
+            httpx.HTTPError: HTTP 요청 실패시
+        """
+        url = settings.spring_boot_endpoints["welding_data"]
+
+        # ✅ SensorDataRequest DTO 형식으로 데이터 구성 (스프링부트가 기대하는 형식)
+        payload = {
+            # String 그대로
+            "machineId": sensor_data.get("machine_id", "WELDING_MACHINE_001"),
+            # timestamp (소문자)
+            "timestamp": sensor_data.get("timestamp", datetime.now().isoformat()),
+            "signalType": sensor_data["signal_type"],  # signalType 필드 추가
+            "sensorValues": sensor_data["values"],     # sensorValues 배열 그대로 전송
+            "dataSource": "simulator"
+        }
+
+        retry_count = 0
+        last_exception = None
+
+        while retry_count <= self.max_retries:
+            try:
+                async with httpx.AsyncClient(timeout=self.timeout) as client:
+                    logger.info(
+                        f"게이트웨이를 통해 스프링부트로 센서 데이터 전송 시도 (시도 {retry_count + 1}/{self.max_retries + 1})")
+                    logger.info(f"URL: {url}")
+                    # DEBUG -> INFO로 변경하여 로그에서 확인
+                    logger.info(f"Payload: {payload}")
+
+                    headers = {
+                        "Content-Type": "application/json",
+                        "X-Source": "welding-simulator",
+                        "X-Gateway-Route": "weldingprocessmonitoring"
+                    }
+
+                    response = await client.post(url, json=payload, headers=headers)
+
+                    # HTTP 상태 코드 확인
+                    response.raise_for_status()
+
+                    result = response.json()
+                    logger.info(f"게이트웨이를 통한 스프링부트 응답 성공: {result}")
+
+                    return result
+
+            except asyncio.CancelledError:
+                logger.info("HTTP 요청이 취소되었습니다.")
+                raise  # CancelledError는 다시 raise해야 함
+
+            except httpx.TimeoutException as e:
+                last_exception = e
+                logger.warning(
+                    f"게이트웨이 타임아웃 (시도 {retry_count + 1}): {str(e)}")
+
+            except httpx.HTTPStatusError as e:
+                last_exception = e
+                logger.error(
+                    f"게이트웨이 HTTP 오류 (시도 {retry_count + 1}): {e.response.status_code} - {e.response.text}")
+
+                # 4xx 오류는 재시도하지 않음
+                if 400 <= e.response.status_code < 500:
+                    raise e
+
+            except httpx.RequestError as e:
+                last_exception = e
+                logger.error(
+                    f"게이트웨이 연결 오류 (시도 {retry_count + 1}): {str(e)}")
+
+            except Exception as e:
+                last_exception = e
+                logger.error(
+                    f"게이트웨이 예상치 못한 오류 (시도 {retry_count + 1}): {str(e)}")
+
+            retry_count += 1
+
+            # 마지막 시도가 아니면 잠시 대기
+            if retry_count <= self.max_retries:
+                try:
+                    await asyncio.sleep(1)
+                except asyncio.CancelledError:
+                    logger.info("재시도 대기 중 작업 취소됨")
+                    raise
+
+        # 모든 재시도 실패
+        logger.error(f"게이트웨이를 통한 스프링부트 전송 실패 - 모든 재시도 완료")
+        raise last_exception
+
+    def _extract_machine_id(self, machine_id_str: str) -> int:
+        """기계 ID에서 숫자만 추출"""
+        import re
+        numbers = re.findall(r'\d+', machine_id_str)
+        return int(numbers[0]) if numbers else 1
+
+    def _format_timestamp(self, timestamp_str: str) -> str:
+        """타임스탬프를 Java Date 형식으로 변환 (짧은 형식 사용)"""
+        try:
+            # 스프링부트 예시에서는 "2025-08-19" 같은 짧은 형식 사용
+            from datetime import datetime
+            if isinstance(timestamp_str, str):
+                # 'Z' 또는 '+00:00' 제거하고 파싱
+                clean_timestamp = timestamp_str.replace(
+                    'Z', '').replace('+00:00', '')
+                dt = datetime.fromisoformat(clean_timestamp)
+            else:
+                dt = datetime.now()
+
+            # 짧은 날짜 형식으로 변환 (예시와 동일하게): "2025-08-19"
+            return dt.strftime('%Y-%m-%d')
+        except Exception as e:
+            logger.warning(f"타임스탬프 변환 실패: {e}, 현재 날짜 사용")
+            return datetime.now().strftime('%Y-%m-%d')
+
+    def _map_sensor_values_to_db_columns(self, values: list) -> Dict[str, float]:
+        """센서 값 배열을 DB 컬럼에 매핑 (기존 엔티티 구조에 맞게)"""
+        def get_value_at_index(index: int) -> Optional[float]:
+            return float(values[index]) if index < len(values) else None
+
+        return {
+            "sensorValue0Ms": get_value_at_index(0),
+            "sensorValue25Ms": get_value_at_index(25),
+            "sensorValue125Ms": get_value_at_index(125),
+            "sensorValue312Ms": get_value_at_index(312),
+            "sensorValue375Ms": get_value_at_index(375),
+            "sensorValue625Ms": get_value_at_index(625),
+            "sensorValue938Ms": get_value_at_index(938),
+            "sensorValue1562Ms": get_value_at_index(1562),
+            "sensorValue1875Ms": get_value_at_index(1875),
+            "sensorValue2188Ms": get_value_at_index(2188),
+            "sensorValue2812Ms": get_value_at_index(2812),
+            "sensorValue3125Ms": get_value_at_index(3125),
+            "sensorValue3438Ms": get_value_at_index(3438),
+            "sensorValue4062Ms": get_value_at_index(4062),
+        }
+
+    async def health_check(self) -> bool:
+        """
+        스프링부트 서비스 헬스 체크 (게이트웨이 경유)
+
+        Returns:
+            서비스 상태 (True: 정상, False: 비정상)
+        """
+        try:
+            url = settings.spring_boot_endpoints["health"]
+
+            async with httpx.AsyncClient(timeout=5) as client:
+                headers = {
+                    "X-Source": "welding-simulator",
+                    "X-Gateway-Route": "weldingprocessmonitoring"
+                }
+
+                response = await client.get(url, headers=headers)
+
+                if response.status_code == 200:
+                    try:
+                        health_data = response.json()
+                        status = health_data.get("status", "").upper()
+                        logger.info(f"게이트웨이를 통한 스프링부트 헬스 체크 성공: {status}")
+                        return status == "UP"
+                    except:
+                        # JSON 파싱 실패 시에도 200이면 정상으로 간주
+                        logger.info("게이트웨이를 통한 스프링부트 헬스 체크 성공 (200 OK)")
+                        return True
+                else:
+                    logger.warning(
+                        f"게이트웨이를 통한 스프링부트 헬스 체크 실패: HTTP {response.status_code}")
+                    return False
+
+        except Exception as e:
+            logger.error(f"게이트웨이를 통한 스프링부트 헬스 체크 오류: {str(e)}")
+            return False
+
+
+# 전역 클라이언트 인스턴스
+spring_client = SpringBootClient()


### PR DESCRIPTION
## ✨ Description
- **시뮬레이터–게이트웨이–스프링부트 연동**: 시뮬레이터가 수집한 용접기 센서 데이터를 **게이트웨이 경유 API**로 전송하도록 통신 계층 추가
- **환경별 URL 자동 전환**: `local / docker / kubernetes / production` 환경에 따라 **게이트웨이·모델 서비스 URL**을 자동 선택
- **초기 헬스 체크 고도화**: 모델 서비스뿐 아니라 **스프링부트 헬스 엔드포인트**까지 점검하여 시작 안정성 향상
- **주기 작업 로직 리팩토링**: 주기적 데이터 수집 후 **스프링부트 전송 흐름**으로 정리(전류/진동 개별 전송, 재시도/로그 보강)
- **CORS 및 라우팅 정리**: 프론트(로컬) 연동을 위한 **CORS 허용** 및 **라우터 prefix 일원화**
- **운영 가시성 향상**: 시작/중지/전송 상태, 대상 URL 등 **런타임 로그**를 구체화

## ✅ TO-DO
- [ ] **Settings (환경/엔드포인트)**:  
  `services/welding-machine-data-simulator-service/app/config/settings.py`  
  - **환경별 게이트웨이/모델 URL 매핑**, **프로덕션 기본값**, **스프링 엔드포인트(health, welding_data)**, **환경 자동 감지 로직** 추가

- [ ] **FastAPI 앱 설정(CORS/라우팅/수명주기)**:  
  `services/welding-machine-data-simulator-service/app/main.py`  
  - **CORS 허용(로컬 프론트 도메인)**, **/simulator, /test prefix 라우팅**, **lifespan에서 로그 디렉토리 준비 및 스케줄러 안전 종료** 적용

- [ ] **스케줄러(수집→전송 플로우)**:  
  `services/welding-machine-data-simulator-service/app/services/scheduler_service.py`  
  - **초기 헬스 체크 시 스프링부트 검사 포함**, **전류/진동 데이터 개별 전송 메서드** 추가, **재시도·예외 처리·로깅 강화**, **상태 조회에 스프링부트 URL/전송모드 포함**

- [ ] **스프링부트 클라이언트(게이트웨이 경유)**:  
  `services/welding-machine-data-simulator-service/app/services/spring_client.py`  
  - **httpx 비동기 클라이언트**, **재시도/타임아웃/상태코드 처리**, **센서 데이터 DTO 포맷(payload) 구성**, **/health 체크** 구현

## 🔗 Reference
- 없음

## 📌 Etc
- 환경 변수 예시: `ENVIRONMENT`, `AZURE_CONNECTION_STRING`  
- 전송 대상 엔드포인트는 **게이트웨이 경유**로 설정됨

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Environment-aware configuration with auto-detection and dynamic service URLs.
  - CORS enabled for http://localhost:3000.
  - Integration with a gateway-backed Spring service for sensor data transmission, with retries and health checks.

- Refactor
  - Simulator now sends data to the Spring service instead of using model predictions; status output updated accordingly.
  - Routers mounted under /simulator and /test; existing endpoints and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->